### PR TITLE
Enable dependabot for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Follow up to https://github.com/jenkins-infra/gatsby-plugin-jenkins-layout/commit/2776f47ab82302a46a21f6c3d8b9dd80c1fbc3ea. Would possibly make sense to track other dependencies too.