### PR TITLE
feat: Disable report link when no source path is set

### DIFF
--- a/makeLayout.js
+++ b/makeLayout.js
@@ -172,7 +172,7 @@ async function makeReactLayout(options = {}) {
             } else if (node.name === 'jio-navbar') {
                 jsxLines.push(`<jio-navbar className="fixed-top" property=${JSON.stringify(options.siteUrl)}></jio-navbar>`);
             } else if (node.name === 'jio-footer') {
-                jsxLines.push(`<jio-footer githubRepo={githubRepo} property=${JSON.stringify(options.siteUrl)} sourcePath={sourcePath} githubBranch=${JSON.stringify(options.githubBranch)}></jio-footer>`);
+                jsxLines.push(`<jio-footer githubRepo={sourcePath ? githubRepo : ''} property=${JSON.stringify(options.siteUrl)} sourcePath={sourcePath} githubBranch=${JSON.stringify(options.githubBranch)}></jio-footer>`);
             } else {
                 jsxLines.push(`${prefix}<${node.name} ${attrs} />`);
             }


### PR DESCRIPTION
"Report problem" used to be hidden in plugins.jenkins.io footer. This should hide it again.

On the main site it makes sense to show "report problem" and not "improve the page" for some pages, so we can't just change this in the footer component.

CC @halkeye @NotMyFault