### PR TITLE
Remove unused variables from Layout component

### DIFF
--- a/makeLayout.js
+++ b/makeLayout.js
@@ -180,13 +180,11 @@ async function makeReactLayout(options = {}) {
     };
 
     jsxLines.push('export default function Layout({ children, id, sourcePath}) {');
-    jsxLines.push(`   const {site: { buildTime, siteMetadata: { githubRepo, siteUrl }}} = useStaticQuery(graphql\`
+    jsxLines.push(`   const {site: { siteMetadata: { githubRepo }}} = useStaticQuery(graphql\`
         query {
             site {
-                buildTime
                 siteMetadata {
                     githubRepo
-                    siteUrl
                 }
             }
         }


### PR DESCRIPTION
I have been encountering these unused variable warnings in the build log of `jenkins-infra/stories`. These should be removed in order to get a clean build. 

<img width="769" height="231" alt="image" src="https://github.com/user-attachments/assets/c539633b-a116-404e-b7d8-4145e16e226a" />

reference: 
https://github.com/jenkins-infra/stories/pull/295