### PR TITLE
docs(.tool-versions): note that nodejs version is managed by updatecli

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-# Managed by https://github.com/jenkins-infra/jenkins-infra/pull/4895
+# Automatically managed and tracked by Updatecli via the manifest https://github.com/jenkins-infra/jenkins-infra/updatecli/updatecli.d/nodejs-consumers.yaml.tpl
 nodejs 24.16.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
+# Managed by https://github.com/jenkins-infra/jenkins-infra/pull/4895
 nodejs 24.16.0


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/5175

The nodejs version in this repo is kept in sync automatically by the updatecli manifest added in jenkins-infra/jenkins-infra#4895(`updatecli/updatecli.d/nodejs-consumers.yaml.tpl`), which reads the Node version from the production packer-images.

This adds a one-time comment so contributors know the value is managed and shouldn't be edited by hand.
